### PR TITLE
add clang format & update gitignore

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 150

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@ ifcc-test-output/
 test
 compiler/config.mk
 test.*
+compiler/.antlr
+
+# IDE
+.vscode/
+
+# Prerequisites
+*.d
+
+# Object files
+*.o


### PR DESCRIPTION
Add auto formatting.

## For VSCode users

- install the official C/C++ extension
- create `.vscode` folder at the root of the project, add a `settings.json`

In the `settings.json` add:

```json
{
    "editor.formatOnSave": true,
}
```

## For CLion users

CLion normally automatically use the `.clang-format` formatting rules. No manual action required.

## Summary by Sourcery

Add project-wide C/C++ formatting configuration and update ignored files.

Enhancements:
- Introduce a .clang-format configuration file to standardize C/C++ code style across the project.

Chores:
- Update .gitignore entries to align with the new formatting setup and local tooling artefacts.